### PR TITLE
feat/order - 주문 생성 API 구현

### DIFF
--- a/controller/order/orderController.js
+++ b/controller/order/orderController.js
@@ -1,0 +1,26 @@
+const { StatusCodes } = require('http-status-codes');
+const orderService = require('../../services/order/orderService');
+
+const orderController = {};
+
+/**
+ * 주문 생성 API
+ * @route POST /order
+ * @param {Object} req - 요청 객체 (주문 정보 포함)
+ * @param {Object} res - 응답 객체
+ */
+orderController.createOrder = async (req, res) => {
+   try {
+      const { userId } = req;
+      const createdOrder = await orderService.createOrder(req.body, userId);
+
+      res.status(StatusCodes.OK).json({ status: 'success', orderNum: createdOrder.orderNum });
+   } catch (error) {
+      console.error('주문 생성 실패:', error);
+      return res
+         .status(StatusCodes.BAD_REQUEST)
+         .json({ status: 'fail', error: '주문 처리 중 오류가 발생했습니다.', message: error.message });
+   }
+};
+
+module.exports = orderController;

--- a/controller/product/productController.js
+++ b/controller/product/productController.js
@@ -13,7 +13,11 @@ productController.createProduct = async (req, res) => {
       console.log(object);
       res.status(StatusCodes.OK).json({ status: 'success', product });
    } catch (error) {
-      res.status(StatusCodes.BAD_REQUEST).json({ status: 'fail', error: error.message });
+      res.status(StatusCodes.BAD_REQUEST).json({
+         status: 'fail',
+         error: '상품 생성 중 오류가 발생했습니다.',
+         message: error.message,
+      });
    }
 };
 
@@ -28,7 +32,11 @@ productController.getProducts = async (req, res) => {
       response = await productService.getProducts({ page, name, response });
       res.status(StatusCodes.OK).json(response);
    } catch (error) {
-      res.status(StatusCodes.BAD_REQUEST).json({ status: 'fail', error: error.message });
+      res.status(StatusCodes.BAD_REQUEST).json({
+         status: 'fail',
+         error: '상품 목록 호출 중 오류가 발생했습니다.',
+         message: error.message,
+      });
    }
 };
 
@@ -44,7 +52,11 @@ productController.updateProduct = async (req, res) => {
       const updatedProduct = await productService.updateProduct(productId, updatedData);
       res.status(StatusCodes.OK).json({ status: 'success', data: updatedProduct });
    } catch (error) {
-      res.status(StatusCodes.BAD_REQUEST).json({ status: 'fail', error: error.message });
+      res.status(StatusCodes.BAD_REQUEST).json({
+         status: 'fail',
+         error: '상품 수정 중 오류가 발생했습니다.',
+         message: error.message,
+      });
    }
 };
 
@@ -59,9 +71,11 @@ productController.getProductById = async (req, res) => {
       res.status(StatusCodes.OK).json({ status: 'success', data: product });
    } catch (error) {
       console.error('상품 상세 조회 실패:', error);
-      return res
-         .status(StatusCodes.BAD_REQUEST)
-         .json({ status: 'fail', error: '상품 정보를 불러오는 중 오류가 발생했습니다.' });
+      return res.status(StatusCodes.BAD_REQUEST).json({
+         status: 'fail',
+         error: '상품 정보를 불러오는 중 오류가 발생했습니다.',
+         message: error.message,
+      });
    }
 };
 
@@ -78,7 +92,26 @@ productController.deleteProduct = async (req, res) => {
       console.error('[ERROR] 상품 삭제 실패:', error);
       return res
          .status(StatusCodes.BAD_REQUEST)
-         .json({ status: 'fail', error: '상품 삭제 중 오류가 발생했습니다.' });
+         .json({ status: 'fail', error: '상품 삭제 중 오류가 발생했습니다.', message: error.message });
    }
 };
+
+/**
+ * 개별 상품 재고 확인 API
+ * @param {Object} item - { productId, size, qty }
+ * @returns {Object} { isVerify: boolean, message?: string }
+ */
+productController.checkStock = async (item) => {
+   return await productService.checkStock(item);
+};
+
+/**
+ * 주문 리스트의 모든 상품 재고 확인 API
+ * @param {Array} orderList - [{ productId, size, qty }]
+ * @returns {Array} 부족한 재고 목록
+ */
+productController.checkItemListStock = async (orderList) => {
+   return await productService.checkItemListStock(orderList);
+};
+
 module.exports = productController;

--- a/models/order.model.js
+++ b/models/order.model.js
@@ -1,10 +1,11 @@
 const mongoose = require('mongoose');
-const User = require('./User');
-const Product = require('./Product');
+const User = require('./user.model');
+const Product = require('./product.model');
+const Cart = require('./cart.model');
 const Schema = mongoose.Schema;
 const orderSchema = Schema(
    {
-      userId: { type: mongoose.ObjectId, ref: User, required: true },
+      userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
       status: { type: String, default: 'preparing' },
       totalPrice: { type: Number, required: true, default: 0 },
       shipTo: { type: Object, required: true },
@@ -27,6 +28,12 @@ orderSchema.methods.toJSON = function () {
    delete obj.updatedAt;
    return obj;
 };
+
+orderSchema.post('save', async function () {
+   const cart = await Cart.findOne({ userId: this.userId });
+   cart.items = [];
+   await cart.save();
+});
 
 const Order = mongoose.model('Order', orderSchema);
 module.exports = Order;

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,10 +5,12 @@ const userApi = require('./user.api');
 const authApi = require('./auth.api');
 const productApi = require('./product.api');
 const cartApi = require('./cart.api');
+const orderApi = require('./order.api');
 
 router.use('/user', userApi);
 router.use('/auth', authApi);
 router.use('/product', productApi);
 router.use('/cart', cartApi);
+router.use('/order', orderApi);
 
 module.exports = router;

--- a/routes/order.api.js
+++ b/routes/order.api.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const authController = require('../controller/auth/authController');
+const orderController = require('../controller/order/orderController');
+const router = express.Router();
+
+router.post('/', authController.authenticate, orderController.createOrder);
+
+module.exports = router;

--- a/services/order/orderService.js
+++ b/services/order/orderService.js
@@ -1,0 +1,34 @@
+const productController = require('../../controller/product/productController');
+const Order = require('../../models/order.model');
+const { randomStringGenerator } = require('../../utils/randomStringGenerator');
+
+/**
+ * 주문을 생성하는 서비스 함수
+ * @param {Object} data - 주문 데이터 (orderList, totalPrice, shipTo, contact 포함)
+ * @returns {Object} 생성된 주문 객체
+ * @throws {Error} 재고가 부족한 경우 예외 발생
+ */
+const createOrder = async (data, userId) => {
+   console.log(userId);
+   const insufficientStockItems = await productController.checkItemListStock(data.orderList);
+
+   if (insufficientStockItems.length > 0) {
+      const errorMessage = insufficientStockItems.map((item) => item.message).join(', ');
+      throw new Error(`주문 실패: ${errorMessage}`);
+   }
+
+   const newOrder = new Order({
+      userId,
+      totalPrice: data.totalPrice,
+      shipTo: data.shipTo,
+      contact: data.contact,
+      items: data.orderList,
+      orderNum: randomStringGenerator(),
+   });
+
+   await newOrder.save();
+
+   return newOrder;
+};
+
+module.exports = { createOrder };

--- a/utils/randomStringGenerator.js
+++ b/utils/randomStringGenerator.js
@@ -1,0 +1,7 @@
+const randomStringGenerator = () => {
+   const randomString = Array.from(Array(10), () => Math.floor(Math.random() * 36).toString(36)).join('');
+
+   return randomString;
+};
+
+module.exports = { randomStringGenerator };


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 장바구니 아이템 수량 수정 API 구현 (`PATCH` `/cart/:id`)
- 장바구니 총 상품 수량 조회 API 구현 (`GET` `/cart/qty`)
- 장바구니 아이템 삭제 API 구현 (`DELETE` `/cart/:id`)
- 주문 생성 API 구현 (`POST` `/order`)


  - 주문 시 상품 재고를 확인 후, 재고가 충분할 경우 주문 정보를 생성
  - 주문 정보(`userId`, `totalPrice`, `shipTo`, `contact`, `items`, `orderNum`)를 DB에 저장
  - 주문 번호(`orderNum`)는 `randomStringGenerator()`함수라는 util함수를 통해 생성
  - 주문 성공 시 `orderNum`(주문 번호)를 클라이언트 사이드에 응답
