### PR TITLE
feat/product - 상품 조회 로직 분리(관리자 페이지/랜딩 페이지)

### DIFF
--- a/controller/product/productController.js
+++ b/controller/product/productController.js
@@ -21,14 +21,33 @@ productController.createProduct = async (req, res) => {
 };
 
 /**
- * 상품 목록 조회 API
+ * [랜딩 페이지(사용자)]상품 목록 조회 API
  * @route GET /product
  */
-productController.getProducts = async (req, res) => {
+productController.getUserProducts = async (req, res) => {
    try {
       const { page, name } = req.query;
       let response = { status: 'success' };
-      response = await productService.getProducts({ page, name, response });
+      response = await productService.getUserProducts({ page, name, response });
+      res.status(StatusCodes.OK).json(response);
+   } catch (error) {
+      res.status(StatusCodes.BAD_REQUEST).json({
+         status: 'fail',
+         error: '상품 목록 호출 중 오류가 발생했습니다.',
+         message: error.message,
+      });
+   }
+};
+
+/**
+ * [관리자 페이지]상품 목록 조회 API
+ * @route GET /product
+ */
+productController.getAdminProducts = async (req, res) => {
+   try {
+      const { page, name } = req.query;
+      let response = { status: 'success' };
+      response = await productService.getAdminProducts({ page, name, response });
       res.status(StatusCodes.OK).json(response);
    } catch (error) {
       res.status(StatusCodes.BAD_REQUEST).json({

--- a/routes/product.api.js
+++ b/routes/product.api.js
@@ -11,8 +11,16 @@ router.post(
    productController.createProduct,
 );
 
-// 전체 상품 조회
-router.get('/', productController.getProducts);
+// 랜딩 페이지(사용자) - 전체 상품 조회
+router.get('/', productController.getUserProducts);
+
+// 관리자 페이지 - 전체 상품 조회
+router.get(
+   '/admin',
+   authController.authenticate,
+   authController.checkAdminPermission,
+   productController.getAdminProducts,
+);
 
 // 상품 정보 수정
 router.put(


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 관리자 페이지와 사용자 페이지에서 조회 되는 상품 목록 API를 분리하여 역할 구분
- 사용자용 상품 조회 API (`GET /products`)
  - `status: "active"` && `isDeleted: false`인 상품만 조회

- 관리자용 상품 조회 API (`GET /admin/products`)
  - 모든 상품 조회 가능 (숨김 상품 포함)
  - 관리자 권한을 미들웨어를 통해 검증